### PR TITLE
Fix transforming .sass file with ?direct

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export default function sassGlobImports(options: PluginOptions = {}): Plugin {
 
   const transform = (src: string): string => {
     // Determine if this is Sass (vs SCSS) based on file extension
-    const isSass = fileName.endsWith('.sass');
+    const isSass = path.extname(fileName).match(/\.sass/i);
 
     // Store base locations
     const searchBases = [filePath];


### PR DESCRIPTION
When using .sass file, `?direct` is appended to the id when passed to the transform hook.

Using string endsWith would always be false in this case. Instead match the extension determined by the path module.